### PR TITLE
feat: add django debug toolbar

### DIFF
--- a/deployment/bahisweb/Dockerfile
+++ b/deployment/bahisweb/Dockerfile
@@ -72,6 +72,7 @@ RUN export > all_env_vars.sh
 
 ENV KOBO_SERVER_HOST="localhost"
 ENV KOBO_RENDERER_HOST="localhost/form-renderer"
+ENV DJANGO_DEBUG="False"
 
 #CMD ["./uwsgi", "bahis.ini"]
 #we need 10s delay to give databases time to initialise

--- a/deployment/bahisweb/Dockerfile
+++ b/deployment/bahisweb/Dockerfile
@@ -76,4 +76,4 @@ ENV DJANGO_DEBUG="False"
 
 #CMD ["./uwsgi", "bahis.ini"]
 #we need 10s delay to give databases time to initialise
-CMD sleep 10 && ./celeryd_bahis start && ./uwsgi bahis.ini
+CMD sleep 10 && python /${SRC_DIR}/kobocat/manage.py collectstatic --noinput && ./celeryd_bahis start && ./uwsgi bahis.ini

--- a/deployment/bahisweb/requirements.txt
+++ b/deployment/bahisweb/requirements.txt
@@ -18,6 +18,7 @@ django-cors-headers==2.0.1
 django-crispy-forms==1.6.1
 django-db-readonly==0.3.2
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
+django-debug-toolbar==1.8
 django-filter==0.7
 django-guardian==1.4.1
 django-nose==1.4.2

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -27,6 +27,9 @@ server {
         root /src_bahis/kobocat/onadata/usermodule;
         try_files $uri $uri/ @fourthStatic;
     }
+    location @fourthStatic {
+        root /src_bahis/kobocat/onadata;
+    }
     location /media {
         alias /src_bahis/kobocat/onadata/media;
     }


### PR DESCRIPTION
## Description

I have added https://github.com/jazzband/django-debug-toolbar so that we can more easily see the SQL calls being made on a page.

Because this is a really old version (1.8) we don't get the nice sidebar but instead a load of stuff gets dumped at the bottom of the page.

Required for road86/bahis-serve#10

@mixmixmix FYI

## Environment Changes

I have added `DJANGO_DEBUG="False" to the bahisweb dockerfile. This should be changed to "True" if you want to debug info to show.

## Dependency Changes

I have added `django-debug-toolbar==1.8` to the requirements.txt.

## Documentation 

Note that you will need to use the docs for v1.8 of django-debug-toolbar, which can be found here:https://github.com/jazzband/django-debug-toolbar/tree/1.8/docs

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
