### PR TITLE
feat: add response timers to nginx logs for better debugging of the slow server

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -34,11 +34,11 @@ services:
 
   nginx:
     restart: always
-    image: nginx:latest
+    image: nginx:latest # TODO move to alpine for smaller size?
     ports:
       - "83:80" #we are using mitmproxy to monitor traffic on port 80
     volumes:
-      - ./nginx/:/etc/nginx/conf.d
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ../../bahis-serve/:/src_bahis
 
 volumes:

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,34 +1,47 @@
-server {
+events {
+    worker_connections 4096;
+}
 
-    listen 80;
-    server_name localhost;
-    proxy_read_timeout 300;
-    proxy_connect_timeout 300;
-    proxy_send_timeout 300;
+http {
+    log_format timed '$remote_addr - $remote_user [$time_local] '
+        '"$request" $status $body_bytes_sent '
+        '"$http_referer" "$http_user_agent"'
+        'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+    access_log /var/log/nginx/access.log timed;
 
-    location / {
-        include uwsgi_params;
-        uwsgi_pass bahisweb:5000;
-        uwsgi_read_timeout 45;
-        uwsgi_send_timeout 45;
+    server {
+
+        listen 80;
+        listen  [::]:80;
+        server_name localhost;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
+
+        location / {
+            include uwsgi_params;
+            uwsgi_pass bahisweb:5000;
+            uwsgi_read_timeout 45;
+            uwsgi_send_timeout 45;
+
+        }
+
+        location /static/ {
+            root /src_bahis/kobocat-template;
+            try_files $uri $uri/ @secondStatic;
+        }
+
+        location @secondStatic {
+            root /src_bahis/kobocat/onadata/apps/main;
+            try_files $uri $uri/ @thirdStatic;
+        }
+        location @thirdStatic {
+            root /src_bahis/kobocat/onadata/usermodule;
+            try_files $uri $uri/ @fourthStatic;
+        }
+        location /media {
+            alias /src_bahis/kobocat/onadata/media;
+        }
 
     }
-
-    location /static/ {
-        root /src_bahis/kobocat-template;
-        try_files $uri $uri/ @secondStatic;
-    }
-
-    location @secondStatic {
-        root /src_bahis/kobocat/onadata/apps/main;
-        try_files $uri $uri/ @thirdStatic;
-    }
-    location @thirdStatic {
-        root /src_bahis/kobocat/onadata/usermodule;
-        try_files $uri $uri/ @fourthStatic;
-    }
-    location /media {
-        alias /src_bahis/kobocat/onadata/media;
-    }
-
 }


### PR DESCRIPTION
## Description

Updates the nginx.conf so that the log format includes request and response timers. This should make debugging the slow speeds easier, hopefully.
