### PR TITLE
feat: add fourth static on nginx

### DIFF
--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -27,6 +27,9 @@ server {
         root /src_bahis/kobocat/onadata/usermodule;
         try_files $uri $uri/ @fourthStatic;
     }
+    location @fourthStatic {
+        root /src_bahis/kobocat/onadata;
+    }
     location /media {
         alias /src_bahis/kobocat/onadata/media;
     }


### PR DESCRIPTION
## Description
There was missing nginx configuration for the fourth static.

The fourth static will server from "/src_bahis/kobocat/onadata" this uri.  
Somehow it missed in the nginx config file

@ChasNelson1990 Could you please review this PR.