### PR TITLE
fix: restore old nginx format to fix routing issues

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - "83:80" #we are using mitmproxy to monitor traffic on port 80
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/:/etc/nginx/conf.d
       - ../../bahis-serve/:/src_bahis
 
 volumes:

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,47 +1,37 @@
-events {
-    worker_connections 4096;
-}
+server {
 
-http {
-    log_format timed '$remote_addr - $remote_user [$time_local] '
-        '"$request" $status $body_bytes_sent '
-        '"$http_referer" "$http_user_agent"'
-        'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
-    access_log /var/log/nginx/access.log timed;
+    listen 80;
+    server_name localhost;
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
 
-    server {
-
-        listen 80;
-        listen  [::]:80;
-        server_name localhost;
-        proxy_read_timeout 300;
-        proxy_connect_timeout 300;
-        proxy_send_timeout 300;
-
-        location / {
-            include uwsgi_params;
-            uwsgi_pass bahisweb:5000;
-            uwsgi_read_timeout 45;
-            uwsgi_send_timeout 45;
-        }
-        location /static/ {
-            root /src_bahis/kobocat-template;
-            try_files $uri $uri/ @secondStatic;
-        }
-        location @secondStatic {
-            root /src_bahis/kobocat/onadata/apps/main;
-            try_files $uri $uri/ @thirdStatic;
-        }
-        location @thirdStatic {
-            root /src_bahis/kobocat/onadata/usermodule;
-            try_files $uri $uri/ @fourthStatic;
-        }
-        location @fourthStatic {
-            root /src_bahis/kobocat/onadata;
-        }
-        location /media {
-            alias /src_bahis/kobocat/onadata/media;
-        }
+    location / {
+        include uwsgi_params;
+        uwsgi_pass bahisweb:5000;
+        uwsgi_read_timeout 45;
+        uwsgi_send_timeout 45;
 
     }
+
+    location /static/ {
+        root /src_bahis/kobocat-template;
+        try_files $uri $uri/ @secondStatic;
+    }
+
+    location @secondStatic {
+        root /src_bahis/kobocat/onadata/apps/main;
+        try_files $uri $uri/ @thirdStatic;
+    }
+    location @thirdStatic {
+        root /src_bahis/kobocat/onadata/apps/usermodule;
+        try_files $uri $uri/ @fourthStatic;
+    }
+    location @fourthStatic {
+        root /src_bahis/kobocat/onadata;
+    }
+    location /media {
+        alias /src_bahis/kobocat/onadata/media;
+    }
+
 }


### PR DESCRIPTION
## Description

Turns out the nginx changes made in #10 broke something around static file serving. The files seemed to be there (could open via the browser address bar, response had correct data, etc.) but none of them got used by the rendered page. This reverts those changes as they aren't vital, just nice debug tools.

## Testing

Local exploratory testing all works fine.

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
