### PR TITLE
feat: apply django migrations inside the bahis-serve dockerfile

### DIFF
--- a/deployment/bahisweb/Dockerfile
+++ b/deployment/bahisweb/Dockerfile
@@ -76,4 +76,4 @@ ENV DJANGO_DEBUG="False"
 
 #CMD ["./uwsgi", "bahis.ini"]
 #we need 10s delay to give databases time to initialise
-CMD sleep 10 && python /${SRC_DIR}/kobocat/manage.py collectstatic --noinput && ./celeryd_bahis start && ./uwsgi bahis.ini
+CMD sleep 10 && python /${SRC_DIR}/kobocat/manage.py collectstatic --noinput && python /${SRC_DIR}/kobocat/manage.py migrate && ./celeryd_bahis start && ./uwsgi bahis.ini

--- a/deployment/bahisweb/Dockerfile
+++ b/deployment/bahisweb/Dockerfile
@@ -76,4 +76,4 @@ ENV DJANGO_DEBUG="False"
 
 #CMD ["./uwsgi", "bahis.ini"]
 #we need 10s delay to give databases time to initialise
-CMD sleep 10 && python /${SRC_DIR}/kobocat/manage.py collectstatic --noinput && python /${SRC_DIR}/kobocat/manage.py migrate && ./celeryd_bahis start && ./uwsgi bahis.ini
+CMD sleep 10 && python /${SRC_DIR}/kobocat/manage.py collectstatic --noinput && python /${SRC_DIR}/kobocat/manage.py migrate bh_module && ./celeryd_bahis start && ./uwsgi bahis.ini


### PR DESCRIPTION
## Description

Now that migrations are working and committed to the repo, we need to make sure we apply them when we deploy bahis-infra.

So the protocol should be:

1. developer makes changes to models in bahis-serve
2. developer runs `makemigrations` in their dev environment, committing migrations to their feature branch
3. reviewer ensure migrations are in any PR and are documented in the PR description
4. bahis-infra automatically applies migrations on the next deploy

relates road86/bahis-serve#25

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [x] New database changes have been committed.
